### PR TITLE
Refactor for code readability (ShailChoksi/lichess-bot#506)

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,9 +10,8 @@ def load_config(config_file):
     with open(config_file) as stream:
         try:
             CONFIG = yaml.safe_load(stream)
-        except Exception as e:
-            logger.error("There appears to be a syntax problem with your config.yml")
-            raise e
+        except Exception:
+            logger.exception("There appears to be a syntax problem with your config.yml")
 
         if "LIDRAUGHTS_BOT_TOKEN" in os.environ:
             CONFIG["token"] = os.environ["LIDRAUGHTS_BOT_TOKEN"]
@@ -20,8 +19,8 @@ def load_config(config_file):
         # [section, type, error message]
         sections = [["token", str, "Section `token` must be a string wrapped in quotes."],
                     ["url", str, "Section `url` must be a string wrapped in quotes."],
-                    ["engine", dict, "Section `engine` must be a dictionary with indented keys followed by colons.."],
-                    ["challenge", dict, "Section `challenge` must be a dictionary with indented keys followed by colons.."]]
+                    ["engine", dict, "Section `engine` must be a dictionary with indented keys followed by colons."],
+                    ["challenge", dict, "Section `challenge` must be a dictionary with indented keys followed by colons."]]
         for section in sections:
             if section[0] not in CONFIG:
                 raise Exception(f"Your config.yml does not have required section `{section[0]}`.")

--- a/lidraughts-bot.py
+++ b/lidraughts-bot.py
@@ -110,7 +110,7 @@ def game_logging_configurer(queue, level):
 
 
 def game_error_handler(error):
-    logger.error("".join(traceback.format_exception(error)))
+    logger.exception("Game ended due to error:", exc_info=error)
 
 
 def start(li, user_profile, config, logging_level, log_filename, one_game=False):
@@ -124,7 +124,8 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
     control_stream.start()
     correspondence_cfg = config.get("correspondence") or {}
     correspondence_checkin_period = correspondence_cfg.get("checkin_period", 600)
-    correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping, args=[control_queue, correspondence_checkin_period])
+    correspondence_pinger = multiprocessing.Process(target=do_correspondence_ping,
+                                                    args=[control_queue, correspondence_checkin_period])
     correspondence_pinger.start()
     correspondence_queue = manager.Queue()
     correspondence_queue.put("")
@@ -135,8 +136,24 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
     queued_processes = 0
 
     logging_queue = manager.Queue()
-    logging_listener = multiprocessing.Process(target=logging_listener_proc, args=(logging_queue, logging_configurer, logging_level, log_filename))
+    logging_listener = multiprocessing.Process(target=logging_listener_proc,
+                                               args=(logging_queue, logging_configurer, logging_level, log_filename))
     logging_listener.start()
+
+    def log_proc_count(change, queued, used):
+        symbol = "+++" if change == "Freed" else "---"
+        logger.info(f"{symbol} Process {change}. Total Queued: {queued}. Total Used: {used}")
+
+    play_game_args = [li,
+                      None,  # will hold the game id
+                      control_queue,
+                      user_profile,
+                      config,
+                      challenge_queue,
+                      correspondence_queue,
+                      logging_queue,
+                      game_logging_configurer,
+                      logging_level]
 
     with multiprocessing.pool.Pool(max_games + 1) as pool:
         while not terminated:
@@ -158,35 +175,20 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                 break
             elif event["type"] == "local_game_done":
                 busy_processes -= 1
-                logger.info(f"+++ Process Free. Total Queued: {queued_processes}. Total Used: {busy_processes}")
+                log_proc_count("Freed", queued_processes, busy_processes)
                 if one_game:
                     break
             elif event["type"] == "challenge":
                 chlng = model.Challenge(event["challenge"])
-                if chlng.is_supported(challenge_config):
+                is_supported, decline_reason = chlng.is_supported(challenge_config)
+                if is_supported:
                     challenge_queue.append(chlng)
                     if challenge_config.get("sort_by", "best") == "best":
                         list_c = list(challenge_queue)
                         list_c.sort(key=lambda c: -c.score())
                         challenge_queue = list_c
                 else:
-                    try:
-                        reason = "generic"
-                        challenge = config["challenge"]
-                        if not chlng.is_supported_variant(challenge["variants"]):
-                            reason = "variant"
-                        if not chlng.is_supported_time_control(challenge["time_controls"], challenge.get("max_increment", 180), challenge.get("min_increment", 0), challenge.get("max_base", 315360000), challenge.get("min_base", 0)):
-                            reason = "timeControl"
-                        if not chlng.is_supported_mode(challenge["modes"]):
-                            reason = "casual" if chlng.rated else "rated"
-                        if not challenge.get("accept_bot", False) and chlng.challenger_is_bot:
-                            reason = "noBot"
-                        if challenge.get("only_bot", False) and not chlng.challenger_is_bot:
-                            reason = "onlyBot"
-                        li.decline_challenge(chlng.id, reason=reason)
-                        logger.info(f"Decline {chlng} for reason '{reason}'")
-                    except Exception:
-                        pass
+                    li.decline_challenge(chlng.id, reason=decline_reason)
             elif event["type"] == "gameStart":
                 game_id = event["game"]["id"]
                 if game_id in startup_correspondence_games:
@@ -197,8 +199,9 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                     if queued_processes > 0:
                         queued_processes -= 1
                     busy_processes += 1
-                    logger.info(f"--- Process Used. Total Queued: {queued_processes}. Total Used: {busy_processes}")
-                    pool.apply_async(play_game, [li, game_id, control_queue, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level], error_callback=game_error_handler)
+                    log_proc_count("Used", queued_processes, busy_processes)
+                    play_game_args[1] = game_id
+                    pool.apply_async(play_game, play_game_args, error_callback=game_error_handler)
 
             is_correspondence_ping = event["type"] == "correspondence_ping"
             is_local_game_done = event["type"] == "local_game_done"
@@ -218,18 +221,20 @@ def start(li, user_profile, config, logging_level, log_filename, one_game=False)
                             break
                     else:
                         busy_processes += 1
-                        logger.info(f"--- Process Used. Total Queued: {queued_processes}. Total Used: {busy_processes}")
-                        pool.apply_async(play_game, [li, game_id, control_queue, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level], error_callback=game_error_handler)
+                        log_proc_count("Used", queued_processes, busy_processes)
+                        play_game_args[1] = game_id
+                        pool.apply_async(play_game, play_game_args, error_callback=game_error_handler)
 
-            while (queued_processes + busy_processes) < max_games and challenge_queue:  # keep processing the queue until empty or max_games is reached
+            # Keep processing the queue until empty or max_games is reached.
+            while (queued_processes + busy_processes) < max_games and challenge_queue:
                 chlng = challenge_queue.pop(0)
                 try:
                     logger.info(f"Accept {chlng}")
                     queued_processes += 1
-                    li.accept_challenge(chlng.id)
+                    log_proc_count("Queued", queued_processes, busy_processes)
                     logger.info(f"--- Process Queue. Total Queued: {queued_processes}. Total Used: {busy_processes}")
                 except (HTTPError, ReadTimeout) as exception:
-                    if isinstance(exception, HTTPError) and exception.response.status_code == 404:  # ignore missing challenge
+                    if isinstance(exception, HTTPError) and exception.response.status_code == 404:
                         logger.info(f"Skip missing {chlng}")
                     queued_processes -= 1
 
@@ -248,7 +253,16 @@ ponder_results = {}
 
 
 @backoff.on_exception(backoff.expo, BaseException, max_time=600, giveup=is_final)
-def play_game(li, game_id, control_queue, user_profile, config, challenge_queue, correspondence_queue, logging_queue, game_logging_configurer, logging_level):
+def play_game(li,
+              game_id,
+              control_queue,
+              user_profile,
+              config,
+              challenge_queue,
+              correspondence_queue,
+              logging_queue,
+              game_logging_configurer,
+              logging_level):
     game_logging_configurer(logging_queue, logging_level)
     logger = logging.getLogger(__name__)
 
@@ -258,7 +272,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
     # Initial response of stream will be the full game info. Store it
     initial_state = json.loads(next(lines).decode("utf-8"))
     logger.debug(f"Initial state: {initial_state}")
-    game = model.Game(initial_state, user_profile["username"], li.baseUrl, config.get("abort_time", 20))
+    abort_time = config.get("abort_time", 20)
+    game = model.Game(initial_state, user_profile["username"], li.baseUrl, abort_time)
 
     initial_time = (game.state["wtime"] if game.my_color == "white" else game.state["btime"]) / 1000
     variant = parse_variant(game.variant_name)
@@ -270,6 +285,7 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
     is_correspondence = game.perf_name == "Correspondence"
     correspondence_cfg = config.get("correspondence") or {}
     correspondence_move_time = correspondence_cfg.get("move_time", 60) * 1000
+    correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)
 
     engine_cfg = config["engine"]
     ponder_cfg = correspondence_cfg if is_correspondence else engine_cfg
@@ -280,7 +296,9 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
 
     greeting_cfg = config.get("greeting") or {}
     keyword_map = defaultdict(str, me=game.me.name, opponent=game.opponent.name)
-    get_greeting = lambda greeting: str(greeting_cfg.get(greeting) or "").format_map(keyword_map)
+
+    def get_greeting(greeting):
+        return str(greeting_cfg.get(greeting) or "").format_map(keyword_map)
     hello = get_greeting("hello")
     goodbye = get_greeting("goodbye")
 
@@ -290,8 +308,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
     ponder_li_one = None
 
     first_move = True
+    disconnect_time = 0
     prior_game = None
-    correspondence_disconnect_time = 0
     while not terminated:
         move_attempted = False
         try:
@@ -319,12 +337,15 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                         board.push_str_move(move)
                 old_moves = moves
 
+                if len(board.move_stack) == 0:
+                    disconnect_time = correspondence_disconnect_time
+
                 if not is_game_over(board) and is_engine_move(game, prior_game, board):
+                    disconnect_time = correspondence_disconnect_time
                     if len(board.move_stack) < 2:
                         conversation.send_message("player", hello)
                     fake_thinking(config, board, game)
                     print_move_number(board)
-                    correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)
 
                     draw_offered = check_for_draw_offer(game)
 
@@ -335,7 +356,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                     else:
                         best_move = get_pondering_results(ponder_thread, ponder_li_one, game, board, engine)
                         if best_move.move is None:
-                            best_move = choose_move(engine, board, game, draw_offered, start_time, move_overhead, move_overhead_inc)
+                            best_move = choose_move(engine, board, game, draw_offered, start_time, move_overhead,
+                                                    move_overhead_inc)
                     move_attempted = True
                     if best_move.resigned and len(board.move_stack) >= 2:
                         li.resign(game.id)
@@ -347,11 +369,10 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
                     engine.report_game_result(game, board)
                     tell_user_game_result(game, board)
                     conversation.send_message("player", goodbye)
-                elif len(board.move_stack) == 0:
-                    correspondence_disconnect_time = correspondence_cfg.get("disconnect_time", 300)
 
                 wb = "w" if board.whose_turn() == draughts.WHITE else "b"
-                game.ping(config.get("abort_time", 20), (upd[f"{wb}time"] + upd[f"{wb}inc"]) / 1000 + 60, correspondence_disconnect_time)
+                terminate_time = (upd[f"{wb}time"] + upd[f"{wb}inc"]) / 1000 + 60
+                game.ping(abort_time, terminate_time, disconnect_time)
                 prior_game = copy.deepcopy(game)
             elif u_type == "ping":
                 if is_correspondence and not is_engine_move(game, prior_game, board) and game.should_disconnect_now():
@@ -378,8 +399,8 @@ def play_game(li, game_id, control_queue, user_profile, config, challenge_queue,
 
     try:
         print_pgn_game_record(li, config, game, board, engine)
-    except Exception as e:
-        logger.warning(f"Error writing game record: {repr(e)}")
+    except Exception:
+        logger.exception("Error writing game record:")
 
     if is_correspondence and not is_game_over(board):
         logger.info(f"--- Disconnecting from {game.url()}")
@@ -418,20 +439,14 @@ def choose_first_move(engine, board, draw_offered):
 
 
 def choose_move(engine, board, game, draw_offered, start_time, move_overhead, move_overhead_inc):
-    wtime = game.state["wtime"]
-    btime = game.state["btime"]
-    winc = game.state["winc"]
-    binc = game.state["binc"]
-    pre_move_time = int((time.perf_counter_ns() - start_time) / 1000000)
-    if board.whose_turn() == draughts.WHITE:
-        wtime = max(0, wtime - move_overhead - pre_move_time)
-        winc = max(0, winc - move_overhead_inc)
-    else:
-        btime = max(0, btime - move_overhead - pre_move_time)
-        binc = max(0, binc - move_overhead_inc)
-
-    logger.info(f"Searching for wtime {wtime} btime {btime}")
-    return engine.search_with_ponder(board, wtime, btime, winc, binc, False, draw_offered)
+    pre_move_time = int((time.perf_counter_ns() - start_time) / 1e6)
+    overhead = pre_move_time + move_overhead
+    wb = "w" if board.turn == draughts.WHITE else "b"
+    game.state[f"{wb}time"] = max(0, game.state[f"{wb}time"] - overhead)
+    game.state[f"{wb}inc"] = max(0, game.state[f"{wb}inc"] - move_overhead_inc)
+    logger.info("Searching for wtime {wtime} btime {btime}".format_map(game.state))
+    return engine.search_with_ponder(board, game.state["wtime"], game.state["btime"], game.state["winc"],
+                                     game.state["binc"], False, draw_offered)
 
 
 def start_pondering(engine, board, game, can_ponder, best_move, start_time, move_overhead, move_overhead_inc):
@@ -569,13 +584,13 @@ def print_pgn_game_record(li, config, game, board, engine):
 
 
 def intro():
-    return r"""
+    return fr"""
     .   _/|
     .  // o\
-    .  || ._)  lidraughts-bot %s
+    .  || ._)  lidraughts-bot {__version__}
     .  //__\
     .  )___(   Play on Lidraughts with a bot
-    """ % __version__
+    """
 
 
 def start_lichess_bot():
@@ -609,6 +624,5 @@ def start_lichess_bot():
 if __name__ == "__main__":
     try:
         start_lichess_bot()
-    except Exception as error:
-        logger.error(error)
-        logger.error(game_error_handler(error))
+    except Exception:
+        logger.exception("Quitting lichess-bot due to an error:")

--- a/lidraughts-bot.py
+++ b/lidraughts-bot.py
@@ -441,7 +441,7 @@ def choose_first_move(engine, board, draw_offered):
 def choose_move(engine, board, game, draw_offered, start_time, move_overhead, move_overhead_inc):
     pre_move_time = int((time.perf_counter_ns() - start_time) / 1e6)
     overhead = pre_move_time + move_overhead
-    wb = "w" if board.turn == draughts.WHITE else "b"
+    wb = "w" if board.whose_turn() == draughts.WHITE else "b"
     game.state[f"{wb}time"] = max(0, game.state[f"{wb}time"] - overhead)
     game.state[f"{wb}inc"] = max(0, game.state[f"{wb}inc"] - move_overhead_inc)
     logger.info("Searching for wtime {wtime} btime {btime}".format_map(game.state))

--- a/lidraughts.py
+++ b/lidraughts.py
@@ -110,7 +110,8 @@ class Lidraughts:
         return self.api_post(ENDPOINTS["accept"].format(challenge_id))
 
     def decline_challenge(self, challenge_id, reason="generic"):
-        return self.api_post(ENDPOINTS["decline"].format(challenge_id), data=f"reason={reason}", headers={"Content-Type": "application/x-www-form-urlencoded"})
+        return self.api_post(ENDPOINTS["decline"].format(challenge_id), data=f"reason={reason}",
+                             headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     def get_profile(self):
         profile = self.api_get(ENDPOINTS["profile"])
@@ -129,6 +130,4 @@ class Lidraughts:
         self.session.headers.update(self.header)
 
     def get_game_pgn(self, game_id):
-        return self.api_get(ENDPOINTS["export"].format(game_id),
-                            get_raw_text=True,
-                            params={"literate": "true"})
+        return self.api_get(ENDPOINTS["export"].format(game_id), get_raw_text=True, params={"literate": "true"})

--- a/model.py
+++ b/model.py
@@ -1,5 +1,8 @@
 import time
 from urllib.parse import urljoin
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Challenge:
@@ -11,38 +14,56 @@ class Challenge:
         self.speed = c_info["speed"]
         self.increment = c_info.get("timeControl", {}).get("increment", -1)
         self.base = c_info.get("timeControl", {}).get("limit", -1)
-        self.challenger = c_info.get("challenger")
-        self.challenger_title = self.challenger.get("title") if self.challenger else None
+        self.challenger = c_info.get("challenger", {})
+        self.challenger_title = self.challenger.get("title")
         self.challenger_is_bot = self.challenger_title == "BOT"
         self.challenger_master_title = self.challenger_title if not self.challenger_is_bot else None
-        self.challenger_name = self.challenger["name"] if self.challenger else "Anonymous"
-        self.challenger_rating_int = self.challenger["rating"] if self.challenger else 0
+        self.challenger_name = self.challenger.get("name", "Anonymous")
+        self.challenger_rating_int = self.challenger.get("rating", 0)
         self.challenger_rating = self.challenger_rating_int or "?"
 
-    def is_supported_variant(self, supported):
-        return self.variant in supported
+    def is_supported_variant(self, challenge_cfg):
+        return self.variant in challenge_cfg["variants"]
 
-    def is_supported_time_control(self, supported_speed, supported_increment_max, supported_increment_min, supported_base_max, supported_base_min):
+    def is_supported_time_control(self, challenge_cfg):
+        speeds = challenge_cfg["time_controls"]
+        increment_max = challenge_cfg.get("max_increment", 180)
+        increment_min = challenge_cfg.get("min_increment", 0)
+        base_max = challenge_cfg.get("max_base", 315360000)
+        base_min = challenge_cfg.get("min_base", 0)
+
         if self.increment < 0:
-            return self.speed in supported_speed
-        return self.speed in supported_speed and supported_increment_max >= self.increment >= supported_increment_min and supported_base_max >= self.base >= supported_base_min
+            return self.speed in speeds
 
-    def is_supported_mode(self, supported):
-        return "rated" in supported if self.rated else "casual" in supported
+        return (self.speed in speeds
+                and increment_min <= self.increment <= increment_max
+                and base_min <= self.base <= base_max)
+
+    def is_supported_mode(self, challenge_cfg):
+        return ("rated" if self.rated else "casual") in challenge_cfg["modes"]
 
     def is_supported(self, config):
-        if not config.get("accept_bot", False) and self.challenger_is_bot:
-            return False
-        if config.get("only_bot", False) and not self.challenger_is_bot:
-            return False
-        variants = config["variants"]
-        tc = config["time_controls"]
-        inc_max = config.get("max_increment", 180)
-        inc_min = config.get("min_increment", 0)
-        base_max = config.get("max_base", 315360000)
-        base_min = config.get("min_base", 0)
-        modes = config["modes"]
-        return self.is_supported_time_control(tc, inc_max, inc_min, base_max, base_min) and self.is_supported_variant(variants) and self.is_supported_mode(modes)
+        try:
+            if not config.get("accept_bot", False) and self.challenger_is_bot:
+                return False, "noBot"
+
+            if config.get("only_bot", False) and not self.challenger_is_bot:
+                return False, "onlyBot"
+
+            if not self.is_supported_time_control(config):
+                return False, "timeControl"
+
+            if not self.is_supported_variant(config):
+                return False, "variant"
+
+            if not self.is_supported_mode(config):
+                return False, ("casual" if self.rated else "rated")
+
+            return True, None
+
+        except Exception:
+            logger.exception("Error while checking challenge:")
+            return False, "generic"
 
     def score(self):
         rated_bonus = 200 if self.rated else 0
@@ -53,7 +74,7 @@ class Challenge:
         return "rated" if self.rated else "casual"
 
     def challenger_full_name(self):
-        return f'{self.challenger_title + " " if self.challenger_title else ""}{self.challenger_name}'
+        return f'{self.challenger_title or ""} {self.challenger_name}'.strip()
 
     def __str__(self):
         return f"{self.perf_name} {self.mode()} challenge from {self.challenger_full_name()}({self.challenger_rating})"
@@ -68,9 +89,10 @@ class Game:
         self.id = json.get("id")
         self.speed = json.get("speed")
         clock = json.get("clock") or {}
-        self.clock_initial = clock.get("initial", 1000 * 3600 * 24 * 365 * 10)  # unlimited = 10 years
+        ten_years_in_ms = 1000 * 3600 * 24 * 365 * 10
+        self.clock_initial = clock.get("initial", ten_years_in_ms)
         self.clock_increment = clock.get("increment", 0)
-        self.perf_name = json.get("perf").get("name") if json.get("perf") else "{perf?}"
+        self.perf_name = json.get("perf", {}).get("name", "{perf?}")
         self.variant_name = json.get("variant")["name"]
         self.white = Player(json.get("white"))
         self.black = Player(json.get("black"))
@@ -132,7 +154,7 @@ class Player:
             return f"AI level {self.aiLevel}"
         else:
             rating = f'{self.rating}{"?" if self.provisional else ""}'
-            return f'{self.title + " " if self.title else ""}{self.name}({rating})'
+            return f'{self.title or ""} {self.name}({rating})'.strip()
 
     def __repr__(self):
         return self.__str__()

--- a/test_bot/lidraughts.py
+++ b/test_bot/lidraughts.py
@@ -6,6 +6,7 @@ from http.client import RemoteDisconnected
 import backoff
 import time
 import draughts
+import json
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,35 @@ class GameStream:
         self.moves_sent = ""
 
     def iter_lines(self):
-        yield b'{"id":"zzzzzzzz","variant":{"key":"standard","name":"Standard","short":"Std"},"clock":{"initial":60000,"increment":2000},"speed":"bullet","perf":{"name":"Bullet"},"rated":true,"createdAt":1600000000000,"white":{"id":"bo","name":"bo","title":"BOT","rating":3000},"black":{"id":"b","name":"b","title":"BOT","rating":3000,"provisional":true},"initialFen":"startpos","type":"gameFull","state":{"type":"gameState","moves":"","wtime":60000,"btime":60000,"winc":2000,"binc":2000,"status":"started"}}'
+        yield json.dumps(
+            {"id": "zzzzzzzz",
+             "variant": {"key": "standard",
+                         "name": "Standard",
+                         "short": "Std"},
+             "clock": {"initial": 60000,
+                       "increment": 2000},
+             "speed": "bullet",
+             "perf": {"name": "Bullet"},
+             "rated": True,
+             "createdAt": 1600000000000,
+             "white": {"id": "bo",
+                       "name": "bo",
+                       "title": "BOT",
+                       "rating": 3000},
+             "black": {"id": "b",
+                       "name": "b",
+                       "title": "BOT",
+                       "rating": 3000,
+                       "provisional": True},
+             "initialFen": "startpos",
+             "type": "gameFull",
+             "state": {"type": "gameState",
+                       "moves": "",
+                       "wtime": 60000,
+                       "btime": 60000,
+                       "winc": 2000,
+                       "binc": 2000,
+                       "status": "started"}}).encode("utf-8")
         time.sleep(1)
         while True:
             time.sleep(0.001)
@@ -54,11 +83,20 @@ class GameStream:
                     pass
             wtime, btime = float(wtime), float(btime)
             time.sleep(0.1)
+            new_game_state = {"type": "gameState",
+                              "moves": moves,
+                              "wtime": int(wtime * 1000),
+                              "btime": int(btime * 1000),
+                              "winc": 2000,
+                              "binc": 2000}
             if event == "end":
-                yield eval(f'b\'{{"type":"gameState","moves":"{moves}","wtime":{int(wtime * 1000)},"btime":{int(btime * 1000)},"winc":2000,"binc":2000,"status":"outoftime","winner":"black"}}\'')
+                new_game_state["status"] = "outoftime"
+                new_game_state["winner"] = "black"
+                yield json.dumps(new_game_state).encode("utf-8")
                 break
             if moves:
-                yield eval(f'b\'{{"type":"gameState","moves":"{moves}","wtime":{int(wtime * 1000)},"btime":{int(btime * 1000)},"winc":2000,"binc":2000,"status":"started"}}\'')
+                new_game_state["status"] = "started"
+                yield json.dumps(new_game_state).encode("utf-8")
 
 
 class EventStream:
@@ -70,7 +108,12 @@ class EventStream:
             yield b''
             time.sleep(1)
         else:
-            yield b'{"type":"gameStart","game":{"id":"zzzzzzzz","source":"friend","compat":{"bot":true,"board":true}}}'
+            yield json.dumps(
+                {"type": "gameStart",
+                 "game": {"id": "zzzzzzzz",
+                          "source": "friend",
+                          "compat": {"bot": True,
+                                     "board": True}}}).encode("utf-8")
 
 
 # docs: https://lidraughts.org/api
@@ -150,7 +193,15 @@ class Lidraughts:
         return
 
     def get_profile(self):
-        profile = {"id": "b", "username": "b", "online": True, "title": "BOT", "url": "https://lidraughts.org/@/bo", "followable": True, "following": False, "blocking": False, "followsYou": False}
+        profile = {"id": "b",
+                   "username": "b",
+                   "online": True,
+                   "title": "BOT",
+                   "url": "https://lidraughts.org/@/b",
+                   "followable": True,
+                   "following": False,
+                   "blocking": False,
+                   "followsYou": False}
         self.set_user_agent(profile["username"])
         return profile
 


### PR DESCRIPTION
These changes focus on code readability through the following changes:

- Use named variables instead of in-line expressions (see draw_or_resign() in lichess-bot.py)
- Changing logic flows to reduced repeated code (see get_lichess_cloud_move() in lichess-bot.py)
- More efficient use of dict.get() with default arguments (see Challenge.__init__() in model.py)
- Creating functions to separate in-line code (see challenge declining in lichess-bot.py)
- Use triple-quoted strings for long multi-line strings (see the Stockfish strategy in test-bot.py)
- As a last resort, splitting function arguments across multiple lines

The flake8 warnings are much reduced